### PR TITLE
Switch imp to importlib in setup.py to support installing for python 3.12+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,12 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+*.egg-info/
 
 # Distribution / packaging
 MANIFEST
 build/
 dist/
+
+# Virtual environments
+venv/

--- a/dbtoolspy/_version.py
+++ b/dbtoolspy/_version.py
@@ -1,2 +1,2 @@
-version_info = (1, 0, 0)
+version_info = (1, 0, 1)
 __version__ = '.'.join(map(str, version_info))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 """
 setup.py file for dbtoolspy
 """
-import imp
+import importlib
 import sys
 # Use setuptools to include build_sphinx, upload/sphinx commands
 try:
@@ -13,7 +13,13 @@ except ImportError:
 
 long_description = open('README.rst').read()
 
-_version = imp.load_source('_version','dbtoolspy/_version.py')
+spec = importlib.util.spec_from_file_location("_version", "dbtoolspy/_version.py")
+if spec is None:
+    raise ImportError("Failed to find module spec for _version.py!")
+
+_version = importlib.util.module_from_spec(spec)
+sys.modules["_version"] = _version
+spec.loader.exec_module(_version)
 
 setup(name='dbtoolspy',
       version=_version.__version__,
@@ -28,7 +34,6 @@ setup(name='dbtoolspy',
                    'Environment :: Console',
                    'Intended Audience :: Developers',
                    'License :: OSI Approved :: BSD License',
-                   'Programming Language :: Python :: 2',
                    'Programming Language :: Python :: 3',
                    ],
       )


### PR DESCRIPTION
Without this, py312+ installs will fail with:

```
Obtaining file:///home/jwlodek/Workspace/dbtoolspy
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [23 lines of output]
      Traceback (most recent call last):
        File "/home/jwlodek/Workspace/dbtoolspy/venv/lib64/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/jwlodek/Workspace/dbtoolspy/venv/lib64/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/jwlodek/Workspace/dbtoolspy/venv/lib64/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 132, in get_requires_for_build_editable
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-zaw4q8_p/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 473, in get_requires_for_build_editable
          return self.get_requires_for_build_wheel(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-zaw4q8_p/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-zaw4q8_p/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-zaw4q8_p/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 512, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-zaw4q8_p/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
        File "<string>", line 6, in <module>
      ModuleNotFoundError: No module named 'imp'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build editable did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.

[notice] A new release of pip is available: 23.2.1 -> 25.1.1
[notice] To update, run: pip install --upgrade pip
```

As an aside, is this package available to install from pypi? When I install `dbtoolspy` I get what seems to be an entirely different package. Perhaps this one could be uploaded and called `epics-dbtoolspy`?